### PR TITLE
Allow username to be accessed by browser autofill

### DIFF
--- a/src/auth/Login.js
+++ b/src/auth/Login.js
@@ -51,10 +51,10 @@ class Login extends Component {
               </span>
               {selectedUser && <AccountCard username={selectedUser} />}
               <form className="form" onSubmit={this.handleSubmit}>
-                <input type="hidden" placeholder="Username" defaultValue={selectedUser} ref={(c) => { this.username = c; } } />
+                <input type="text" style={{ display: 'none' }} placeholder="Username" defaultValue={selectedUser} ref={(c) => { this.username = c; }} />
                 <div className="input-group input-group-lg">
                   <span className="input-group-addon"><i className="icon icon-md material-icons">lock_outline</i></span>
-                  <input autoFocus type="password" placeholder="Password or posting WIF" className="form-control" ref={(c) => { this.passwordOrWif = c; } } />
+                  <input autoFocus type="password" placeholder="Password or posting WIF" className="form-control" ref={(c) => { this.passwordOrWif = c; }} />
                 </div>
                 {this.props.auth.errorMessage &&
                   <ul className="errorMessages p-3">


### PR DESCRIPTION
Browser look for username in `text or email or url or tel or number` and hidden is ignored.